### PR TITLE
Small changes related to CakePHP best practices and performance tweaks

### DIFF
--- a/cake-3.0/config/bootstrap.php
+++ b/cake-3.0/config/bootstrap.php
@@ -179,17 +179,9 @@ Request::addDetector('tablet', function ($request) {
  *
  */
 
-Plugin::load('Migrations');
-
-// Only try to load DebugKit in development mode
-// Debug Kit should not be installed on a production system
-if (Configure::read('debug')) {
-    Plugin::load('DebugKit', ['bootstrap' => true]);
-}
 
 /**
  * Connect middleware/dispatcher filters.
  */
-DispatcherFactory::add('Asset');
 DispatcherFactory::add('Routing');
 DispatcherFactory::add('ControllerFactory');

--- a/cake-3.0/config/bootstrap.php
+++ b/cake-3.0/config/bootstrap.php
@@ -68,18 +68,6 @@ try {
     die($e->getMessage() . "\n");
 }
 
-// Load an environment local configuration file.
-// You can use a file like app_local.php to provide local overrides to your
-// shared configuration.
-//Configure::load('app_local', 'default');
-
-// When debug = false the metadata cache should last
-// for a very very long time, as we don't want
-// to refresh the cache while users are doing requests.
-if (!Configure::read('debug')) {
-    Configure::write('Cache._cake_model_.duration', '+1 years');
-    Configure::write('Cache._cake_core_.duration', '+1 years');
-}
 
 /**
  * Set server timezone to UTC. You can change it to another timezone of your
@@ -131,54 +119,6 @@ if (!Configure::read('App.fullBaseUrl')) {
     }
     unset($httpHost, $s);
 }
-
-Cache::config(Configure::consume('Cache'));
-ConnectionManager::config(Configure::consume('Datasources'));
-Email::configTransport(Configure::consume('EmailTransport'));
-Email::config(Configure::consume('Email'));
-Log::config(Configure::consume('Log'));
-Security::salt(Configure::consume('Security.salt'));
-
-/**
- * The default crypto extension in 3.0 is OpenSSL.
- * If you are migrating from 2.x uncomment this code to
- * use a more compatible Mcrypt based implementation
- */
-// Security::engine(new \Cake\Utility\Crypto\Mcrypt());
-
-/**
- * Setup detectors for mobile and tablet.
- */
-Request::addDetector('mobile', function ($request) {
-    $detector = new \Detection\MobileDetect();
-    return $detector->isMobile();
-});
-Request::addDetector('tablet', function ($request) {
-    $detector = new \Detection\MobileDetect();
-    return $detector->isTablet();
-});
-
-/**
- * Custom Inflector rules, can be set to correctly pluralize or singularize
- * table, model, controller names or whatever other string is passed to the
- * inflection functions.
- *
- * Inflector::rules('plural', ['/^(inflect)or$/i' => '\1ables']);
- * Inflector::rules('irregular' => ['red' => 'redlings']);
- * Inflector::rules('uninflected', ['dontinflectme']);
- * Inflector::rules('transliteration', ['/å/' => 'aa']);
- */
-
-/**
- * Plugins need to be loaded manually, you can either load them one by one or all of them in a single call
- * Uncomment one of the lines below, as you need. make sure you read the documentation on Plugin to use more
- * advanced ways of loading plugins
- *
- * Plugin::loadAll(); // Loads all plugins at once
- * Plugin::load('Migrations'); //Loads a single plugin named Migrations
- *
- */
-
 
 /**
  * Connect middleware/dispatcher filters.

--- a/cake-3.0/config/routes.php
+++ b/cake-3.0/config/routes.php
@@ -41,40 +41,11 @@ use Cake\Routing\Router;
  */
 Router::defaultRouteClass('Route');
 
-Router::scope('/', function ($routes) {
+Router::scope('/hello', function ($routes) {
     /**
      * Here, we are connecting '/' (base path) to a controller called 'Pages',
      * its action called 'display', and we pass a param to select the view file
      * to use (in this case, src/Template/Pages/home.ctp)...
      */
-    $routes->connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
-
-    /**
-     * ...and connect the rest of 'Pages' controller's URLs.
-     */
-    $routes->connect('/pages/*', ['controller' => 'Pages', 'action' => 'display']);
-
-    /**
-     * Connect catchall routes for all controllers.
-     *
-     * Using the argument `InflectedRoute`, the `fallbacks` method is a shortcut for
-     *    `$routes->connect('/:controller', ['action' => 'index'], ['routeClass' => 'InflectedRoute']);`
-     *    `$routes->connect('/:controller/:action/*', [], ['routeClass' => 'InflectedRoute']);`
-     *
-     * Any route class can be used with this method, such as:
-     * - DashedRoute
-     * - InflectedRoute
-     * - Route
-     * - Or your own route class
-     *
-     * You can remove these routes once you've connected the
-     * routes you want in your application.
-     */
-    $routes->fallbacks('InflectedRoute');
+    $routes->connect('/', ['controller' => 'Hello', 'action' => 'index']);
 });
-
-/**
- * Load all plugin routes.  See the Plugin documentation on
- * how to customize the loading of plugin routes.
- */
-Plugin::routes();

--- a/cake-3.0/src/Controller/AppController.php
+++ b/cake-3.0/src/Controller/AppController.php
@@ -26,16 +26,4 @@ use Cake\Controller\Controller;
  */
 class AppController extends Controller
 {
-
-    /**
-     * Initialization hook method.
-     *
-     * Use this method to add common initialization code like loading components.
-     *
-     * @return void
-     */
-    public function initialize()
-    {
-        $this->loadComponent('Flash');
-    }
 }

--- a/cake-3.0/src/Controller/HelloController.php
+++ b/cake-3.0/src/Controller/HelloController.php
@@ -8,6 +8,7 @@ class HelloController extends AppController
 
     public function index()
     {
-        echo 'Hello World!';
+        $this->response->body('Hello World!');
+        return $this->response;
     }
 }


### PR DESCRIPTION
I have made a few changes to correct how the frameworks was being used, specially echoing in the controller which is not an accepted practice in the community.

I have also made some slight changes for performance in a way that they are still fair to the other frameworks in this repository:

* Only connected a single route. The majority of the other framework samples only had 1 route.
* Removed development plugins, there is no need for them
* Removed the development oriented "AssetsDispatcher". That's an usual common practice before going live.
* Removed the use of unused component in the application, loading code that is not needed by default is not something you would do in a normal application.