### PR TITLE
Update setup for Yii 2.0

### DIFF
--- a/yii-2.0/_benchmark/setup.sh
+++ b/yii-2.0/_benchmark/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Yii 2.0 requires composer-asset-plugin
-composer global require "fxp/composer-asset-plugin:~1.0.3"
+composer global require "fxp/composer-asset-plugin:~1.1.1"
 
 composer install --no-dev --optimize-autoloader
 chmod o+w assets/ runtime/ web/assets/


### PR DESCRIPTION
latest version of composer requires `~1.1.1` of composer asset plugin to work properly.