### PR TITLE
Update Kernel.php

### DIFF
--- a/laravel-5.3/app/Http/Kernel.php
+++ b/laravel-5.3/app/Http/Kernel.php
@@ -24,12 +24,12 @@ class Kernel extends HttpKernel
      */
     protected $middlewareGroups = [
         'web' => [
-            \App\Http\Middleware\EncryptCookies::class,
-            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-            \Illuminate\Session\Middleware\StartSession::class,
-            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-            \App\Http\Middleware\VerifyCsrfToken::class,
-            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            // \App\Http\Middleware\EncryptCookies::class,
+            // \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+            // \Illuminate\Session\Middleware\StartSession::class,
+            // \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+            // \App\Http\Middleware\VerifyCsrfToken::class,
+            // \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
 
         'api' => [


### PR DESCRIPTION
Laravel comes with HTTP sessions enabled out of the box even though this hurts "hello world" style benchmark times. You are making a comparison to frameworks which do not have sessions enabled out of the box. Disabling sessions to make the comparisons more realistic and accurate.